### PR TITLE
Use appid between homescreen-service and apps

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -23,16 +23,7 @@ void SyncDrawHandler(json_object *object)
 
 void TapShortcutHandler(json_object *object)
 {
-	json_object *appnameJ = nullptr;
-	if(json_object_object_get_ex(object, "application_name", &appnameJ))
-	{
-		const char *appname = json_object_get_string(appnameJ);
-
-		if(myname == QString(appname))
-		{
-			qwm->activateSurface(myname);
-		}
-	}
+	qwm->activateSurface(myname);
 }
 
 int main(int argc, char *argv[], char *env[])


### PR DESCRIPTION
Use appid between hss and apps, and check event destination in libhomescreen. 
So these is no need compare code when recived Event_TapShortcut Event.

BUG-AGL: SPEC-1645