### PR TITLE
delete check appname in tap_shortcut event and change activateSurface to activateWindow

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -23,16 +23,8 @@ void SyncDrawHandler(json_object *object)
 
 void TapShortcutHandler(json_object *object)
 {
-	json_object *appnameJ = nullptr;
-	if(json_object_object_get_ex(object, "application_name", &appnameJ))
-	{
-		const char *appname = json_object_get_string(appnameJ);
-
-		if(myname == QString(appname))
-		{
-			qwm->activateSurface(myname);
-		}
-	}
+    cerr << "activateWindow " << myname.toStdString().c_str() << endl;
+    qwm->activateWindow(myname);
 }
 
 int main(int argc, char *argv[], char *env[])
@@ -90,7 +82,7 @@ int main(int argc, char *argv[], char *env[])
     if (mainapp->StartMonitoringUserInput() < 0)
         return -1;
 
-	qwm->activateSurface(myname);
+	qwm->activateWindow(myname);
 
     /* main loop: */
     return a.exec();


### PR DESCRIPTION
1.because of now homescreen-service emit event to one application,
delete the applciation_name check.
2.activateSurface was deprecated in libwindowmanager,change to activateWindow.

Bug-AGL: SPEC-1764