### PR TITLE
autobuild: add autobuild scripts

### DIFF
--- a/autobuild/agl/autobuild
+++ b/autobuild/agl/autobuild
@@ -1,0 +1,60 @@
+#!/usr/bin/make -f
+# Copyright (C) 2015 - 2018 "IoT.bzh"
+# Author "Romain Forlot" <romain.forlot@iot.bzh>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	 http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+THISFILE  := $(lastword $(MAKEFILE_LIST))
+BUILD_DIR := $(abspath $(dir $(THISFILE))/../../build)
+DEST      := ${BUILD_DIR}
+
+.PHONY: all clean distclean configure build package help
+
+all: help
+
+help:
+	@echo "List of targets available:"
+	@echo ""
+	@echo "- all"
+	@echo "- clean"
+	@echo "- distclean"
+	@echo "- configure"
+	@echo "- build: compilation, link and prepare files for package into a widget"
+	@echo "- package: output a widget file '*.wgt'"
+	@echo "- install: install in your ${CMAKE_INSTALL_DIR} directory"
+	@echo ""
+	@echo "Usage: ./autobuild/agl/autobuild package DEST=${HOME}/opt"
+	@echo "Don't use your build dir as DEST as wgt file is generated at this location"
+
+clean:
+	@([ -d ${BUILD_DIR} ] && make -C ${BUILD_DIR} ${CLEAN_ARGS} clean) || echo Nothing to clean
+
+distclean:
+	@rm -rf ${BUILD_DIR}
+
+configure:
+	@[ -d ${BUILD_DIR} ] || mkdir -p ${BUILD_DIR}
+	@[ -f ${BUILD_DIR}/Makefile ] || (cd ${BUILD_DIR} && cmake ${CONFIGURE_ARGS} ..)
+
+build: configure
+	@cmake --build ${BUILD_DIR} ${BUILD_ARGS} --target all
+
+package: build
+	@cmake --build ${BUILD_DIR} ${PACKAGE_ARGS} --target package
+	@if [ "${DEST}" != "${BUILD_DIR}/$@" ]; then \
+		mkdir -p ${DEST} && cp ${BUILD_DIR}/$@/*.wgt ${DEST}; \
+	fi
+
+install: build
+	@cmake --build ${BUILD_DIR} ${INSTALL_ARGS} --target install
+

--- a/autobuild/linux/autobuild
+++ b/autobuild/linux/autobuild
@@ -1,0 +1,60 @@
+#!/usr/bin/make -f
+# Copyright (C) 2015 - 2018 "IoT.bzh"
+# Author "Romain Forlot" <romain.forlot@iot.bzh>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	 http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+THISFILE  := $(lastword $(MAKEFILE_LIST))
+BUILD_DIR := $(abspath $(dir $(THISFILE))/../../build)
+DEST      := ${BUILD_DIR}
+
+.PHONY: all clean distclean configure build package help
+
+all: help
+
+help:
+	@echo "List of targets available:"
+	@echo ""
+	@echo "- all"
+	@echo "- clean"
+	@echo "- distclean"
+	@echo "- configure"
+	@echo "- build: compilation, link and prepare files for package into a widget"
+	@echo "- package: output a widget file '*.wgt'"
+	@echo "- install: install in your ${CMAKE_INSTALL_DIR} directory"
+	@echo ""
+	@echo "Usage: ./autobuild/agl/autobuild package DEST=${HOME}/opt"
+	@echo "Don't use your build dir as DEST as wgt file is generated at this location"
+
+clean:
+	@([ -d ${BUILD_DIR} ] && make -C ${BUILD_DIR} ${CLEAN_ARGS} clean) || echo Nothing to clean
+
+distclean:
+	@rm -rf ${BUILD_DIR}
+
+configure:
+	@[ -d ${BUILD_DIR} ] || mkdir -p ${BUILD_DIR}
+	@[ -f ${BUILD_DIR}/Makefile ] || (cd ${BUILD_DIR} && cmake ${CONFIGURE_ARGS} ..)
+
+build: configure
+	@cmake --build ${BUILD_DIR} ${BUILD_ARGS} --target all
+
+package: build
+	@cmake --build ${BUILD_DIR} ${PACKAGE_ARGS} --target package
+	@if [ "${DEST}" != "${BUILD_DIR}/$@" ]; then \
+		mkdir -p ${DEST} && cp ${BUILD_DIR}/$@/*.wgt ${DEST}; \
+	fi
+
+install: build
+	@cmake --build ${BUILD_DIR} ${INSTALL_ARGS} --target preinstall
+	@cmake -DBUILD_TYPE=Debug ${INSTALL_ARGS} -P ${BUILD_DIR}/cmake_install.cmake


### PR DESCRIPTION
The autobuild scripts provide an unified way
to build agl apps & services; for the agl
modules missing these scripts, a workaround is
in place to warn of this scenario and allow
for build completion.
This commit add these missing scripts for
genivi-navi-yelp-client (aka poiapp)
The original scripts are slimmed down and adapted
to the existing cmake files without modifying them.

- autobuild/agl/autobuild: allows aglwgt_package
  task to complete, eliminating the verbose
  warnings.
- autobuild/linux/autobuild: allows to build
  the wgt file natively on linux using the agl
  sdk.

Signed-off-by: Raquel Medina <raquel.medina@konsulko.com>